### PR TITLE
#8 Update logging system and enhance `hotrun` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A GTK Shell configuration that combines Adwaita and AGS.
     - systemd-networkd (because I never liked NetworkManager)
 - nushell for the make.nu file
 
-## Installation
+## Installation and running
 
 1. Install the required dependencies
 2. Clone this repository
@@ -26,10 +26,13 @@ A GTK Shell configuration that combines Adwaita and AGS.
     - Run the command `./make.nu -h` to see your options
     - Run the command `./make.nu -h` to see your options
     - Run the command `./make.nu hotrun` to test ags-shell without installation
-    - Run the command
-      `./make.nu install` to install ags-shell in the $XDG_BIN_HOME folder or the
-      `$HOME/.local/bin` folder, which allows you to access the
-      `ags-shell` command in your PATH
+    - Run the command `./make.nu install` to install ags-shell in the $XDG_BIN_HOME folder or the `$HOME/.local/bin` folder, which allows you to access the `ags-shell` command in your PATH
+
+### Log and debugging
+
+I have implemented a logging system by severity level (`CRITICAL`, `ERROR`, `WARNING`, `INFO`, and `DEBUG`). The default level is `INFO`. It is possible to change the log level using the environment variable `AGWAITA_LOG_LEVEL`. e.g. `AGWAITA_LOG_LEVEL=DEBUG ags-shell`
+
+`make.nu hotrun` also provides argument to set the log level (default: `DEBUG`). e.g `make.nu hotrun -l CRITICAL`
 
 ## Preview
 

--- a/make.nu
+++ b/make.nu
@@ -33,6 +33,10 @@ def commands_check [] {
   [ "install" "build" "hotrun" "run" "check" "clean" "init" ]
 }
 
+def agwaita_log_level [] {
+  ["CRITICAL" "ERROR" "WARNING" "INFO" "DEBUG"]
+}
+
 # Script
 
 # Build and install `ags-shell`
@@ -55,10 +59,14 @@ def "main build" [] {
 }
 
 # Run `ags-shell` directly
-def "main hotrun" [] {
+def "main hotrun" [
+  --log-level(-l): string@agwaita_log_level = "DEBUG"
+] {
   main init
   log info "run with ags directly..."
-  ags run ./app.tsx
+  with-env {AGWAITA_LOG_LEVEL: $log_level} {
+    ags run ./app.tsx
+  }
 }
 
 # Build and run `ags-shell` binary

--- a/src/lib/Logger.ts
+++ b/src/lib/Logger.ts
@@ -1,14 +1,33 @@
+import GLib from "gi://GLib"
+
 /**
  * @type {Readonly<Record<LogLevelKey, string>>}
  * L'objet 'LogLevel' mappe le niveau (clé) à son code court (valeur).
  */
 const LogLevel = {
-    CRITICAL: "C",
-    ERROR: "E",
-    WARNING: "W",
-    INFO: "I",
-    DEBUG: "D",
+    CRITICAL: {
+        key: "C",
+        priority: 0
+    },
+    ERROR: {
+        key: "E",
+        priority: 1
+    },
+    WARNING: {
+        key: "W",
+        priority: 2
+    },
+    INFO: {
+        key: "I",
+        priority: 3
+    },
+    DEBUG: {
+        key: "D",
+        priority: 4
+    },
 } as const
+
+const AGWAITA_LOG_LEVEL_ENV_KEY = "AGWAITA_LOG_LEVEL"
 
 type LogLevelKey = keyof typeof LogLevel
 type LogLevelValue = typeof LogLevel[LogLevelKey]
@@ -34,14 +53,22 @@ export const Log = new class {
         this.printLog(LogLevel.DEBUG, tag, msg)
     }
 
+    private get currentAgwaitaLogLevel() {
+        let variable = GLib.getenv(AGWAITA_LOG_LEVEL_ENV_KEY)?.toLocaleUpperCase() as LogLevelKey
+        if (LogLevel[variable] == null) variable = "INFO" as LogLevelKey
+        return LogLevel[variable]
+    }
+
     private printLog(level: LogLevelValue, tag: string, msg: string, err?: Error | unknown | null | undefined) {
+        if (this.currentAgwaitaLogLevel.priority < level.priority) return
+
         const date = new Date()
 
-        const log = `${date.toLocaleString()}|${level}|${tag.substring(0, 25).padEnd(25, "_")}|${msg}${err ? `: ${err}` : ""}`
+        const log = `${date.toLocaleString()}|${level.key}|${tag.substring(0, 25).padEnd(25, "_")}|${msg}${err ? `: ${err}` : ""}`
 
-        if (level === "C" || level === "E" || level === "W") {
+        if (level.key === "C" || level.key === "E" || level.key === "W") {
             printerr(log)
-        } else if (level === "I" || level === "D") {
+        } else if (level.key === "I" || level.key === "D") {
             print(log)
         }
     }


### PR DESCRIPTION
- [x] Introduce an environment variable (e.g., `AGWAITA_LOG_LEVEL`)
- [x] Support the standard log levels: debug, info, warn, error
- [x] Map the environment variable to the internal logger’s filtering logic
- [x] Ensure unknown or invalid values fall back to a safe default
- [x] Add documentation for the available levels and usage examples  

Relate to #8